### PR TITLE
Bug fix: nearest_larger solution failed in some cases

### DIFF
--- a/coding-test-2/practice-problems/solutions/00_nearest_larger.rb
+++ b/coding-test-2/practice-problems/solutions/00_nearest_larger.rb
@@ -8,8 +8,10 @@ def nearest_larger(arr, idx)
       return left
     elsif (right < arr.length) && (arr[right] > arr[idx])
       return right
-    else
+    elsif (left < 0) && (right >= arr.length)
       return nil
     end
+    
+    diff += 1
   end
 end

--- a/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
+++ b/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
@@ -31,6 +31,14 @@ describe "#nearest_larger" do
     nearest_larger([2,6,4,6], 2).should == 1
   end
 
+  it "handles a case with an answer > 1 distance to the left" do
+    nearest_larger([8,2,4,3], 2).should == 0
+  end
+  
+  it "handles a case with an answer > 1 distance to the right" do
+    nearest_larger([2,4,3,8], 1).should == 3
+  end
+
   it "should return nil if no larger number is found" do
     nearest_larger( [2, 6, 4, 8], 3).should == nil
   end


### PR DESCRIPTION
nearest_larger sample solution failed on inputs where the nearest_larger
number was at a distance > 1 from the input index, returned nil in error.

Fixed this and added rspec test cases.
