### PR TITLE
Typo and reference to Standard Library

### DIFF
--- a/mini-curriculum/data-structures/hash.md
+++ b/mini-curriculum/data-structures/hash.md
@@ -165,7 +165,7 @@ In Math a Set is an exclusive list of numbers. Examples are the best way to show
 In a set, order does not matter. So, {5,3,6} is the same as the one above. So, you can see, the actual index or order of these numbers do not matter, as they would were they to be held in an array. 
 
 
-Ruby provides a class named `Set` in the Standard Library. You can read all about it in the
+Ruby provides a class named `Set` in its Standard Library. You can read all about it in the
 [ruby-doc][ruby-doc]. Let's make a set of methods that will manipulate
 a `Hash` as if it were a `Set`.  Like so:
 


### PR DESCRIPTION
I fixed a typo in "exclusive" and added a reference to the Standard Library where Set is introduced.
