### PR TITLE
Fixed typo, said 'probability of begin selected' should say 'probability...

### DIFF
--- a/mini-curriculum/data-structures/array.md
+++ b/mini-curriculum/data-structures/array.md
@@ -355,7 +355,7 @@ die.last
 
 ##  Random (discrete uniform) sampling from arrays
 
-The `sample` method selects an element at random from the array where each element has equal probability of begin selected.  This does not alter the array.
+The `sample` method selects an element at random from the array where each element has equal probability of being selected.  This does not alter the array.
 
 ```ruby
 


### PR DESCRIPTION
Fixed typo, said 'probability of begin selected' should say 'probability of being selected'.
