### PR TITLE
Add May 5th NY Google Group link to Mailing List

### DIFF
--- a/pre-course/mailing-signup.md
+++ b/pre-course/mailing-signup.md
@@ -8,6 +8,7 @@ been sent an acceptance letter**.
 * [2014-01-27 (SF)][2014-01-27-sf]
 * [2014-03-03 (NY)][2014-03-03-ny]
 * [2014-03-31 (SF)][2014-03-31-sf]
+* [2014-05-05 (NY)][2014-05-05-ny]
 
 Please also **send your github username to admin@appacademy.io** so that
 we can add you to the curriculum repos.
@@ -16,3 +17,4 @@ we can add you to the curriculum repos.
 [2014-01-27-sf]: https://groups.google.com/forum/?hl=en#!forum/app-academy-sf-jan-2014-cohort
 [2014-03-03-ny]: https://groups.google.com/forum/#!forum/app-academy-ny-march-2014-cohort
 [2014-03-31-sf]: https://groups.google.com/forum/#!forum/app-academy-march-2014-san-francisco
+[2014-05-05-ny]: https://groups.google.com/forum/#!forum/aa-2014-05-05-ny


### PR DESCRIPTION
Added the Google Group link (https://groups.google.com/forum/#!forum/aa-2014-05-05-ny) for the May 5th NY Cycle to the Mailing List.
