### PR TITLE
add test case for 2 answers to the left selecting the nearest

### DIFF
--- a/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
+++ b/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
@@ -38,6 +38,10 @@ describe "#nearest_larger" do
   it "handles a case with an answer > 1 distance to the right" do
     nearest_larger([2,4,3,8], 1).should == 3
   end
+  
+  it "handles a case with 2 answers to the left selecting the nearest" do
+    nearest_larger( [2, 6, 9, 4, 8], 3).should == 2
+  end
 
   it "should return nil if no larger number is found" do
     nearest_larger( [2, 6, 4, 8], 3).should == nil


### PR DESCRIPTION
I may be a little confused on best practices for testing; I'm not sure. i.e. this may be overkill.

In solving the first test problem in 00_nearest_integer and I wrote a method that gave me green for all of the written tests in the corresponding spec

``` ruby
def nearest_larger(arr, idx)
  test = arr.map do |element|
    if element > arr[idx]
      element
    else
      nil
    end
  end
  test.find_index { |element| element != nil }  
end
```

However, this method doesn't satisfy another reasonable scenario indicated in the test case I added in my PR. 

``` ruby
nearest_larger( [2, 6, 9, 4, 8], 3)

#would return 1 when it should return 2, but this method passes the spec as is. 
```

In the real world would a developer be expected to write a spec that covers the basic cases for testing functionality and then when writing the actual methods account for less obvious cases (as I _didn't_ in the method above)? Or should we be adding to the spec as I have here?

Looking for best practice, real-world answer here.Thanks!
