### PR TITLE
Update Gemfile

### DIFF
--- a/coding-test-2/practice-problems/Gemfile
+++ b/coding-test-2/practice-problems/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'rspec', "~> 2.14.1"
-gem 'debugger'
+gem 'byebug'


### PR DESCRIPTION
debugger no longer works with ruby 2.X
See https://github.com/cldwalker/debugger/issues/125
