### PR TITLE
Updated 00_spec

### DIFF
--- a/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
+++ b/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
@@ -20,7 +20,7 @@ describe "#nearest_larger" do
   end
 
   it "handles a simple case to the left" do
-    nearest_larger([2,8,4,3], 2).should == 1
+    nearest_larger([6,8,4,3], 2).should == 1
   end
 
   it "treats any two larger numbers like a tie" do


### PR DESCRIPTION
Previous version was passable with incorrect methods that simply pick the earliest larger number as opposed to the nearest larger number.
