### PR TITLE
Fix typo in 03_ordered_vowels_spec.rb

### DIFF
--- a/coding-test-2/practice-problems/spec/03_ordered_vowels_spec.rb
+++ b/coding-test-2/practice-problems/spec/03_ordered_vowels_spec.rb
@@ -20,7 +20,7 @@ describe "#ordered_vowel_words" do
     ordered_vowel_words("complicated").should == ""
   end
 
-  it "handle double vowels" do
+  it "handles double vowels" do
     ordered_vowel_words("afoot").should == "afoot"
   end
 


### PR DESCRIPTION
Update coding-test-2/practice-problems/spec/03_ordered_vowels_spec.rb: change 'it handle' to 'it handles' for grammatical correctness.
