### PR TITLE
A Little Typo I Noticed

### DIFF
--- a/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
+++ b/coding-test-2/practice-problems/spec/00_nearest_larger_spec.rb
@@ -6,7 +6,7 @@ require 'rspec'
 # satisfy:
 #
 # (a) `arr[i] < arr[j]`, AND
-# (b) there is no `j2` closer to `i` than `j` where `arr[i] < arr[j]`.
+# (b) there is no `j2` closer to `i` than `j` where `arr[i] < arr[j2]`.
 #
 # In case of ties (see example below), choose the earliest (left-most)
 # of the two indices. If no number in `arr` is larger than `arr[i]`,


### PR DESCRIPTION
Looking at the second-round practice problem specs, I noticed that it says "(b) there is no `j2` closer to `i` than `j` where `arr[i] < arr[j]`."  It's clear that what you mean is that there's no j2 such that arr[i] < arr[j2], and I'm sure most applicants read it that way anyway.  But I thought I'd point out the typo for clarity (and make my first GitHub pull request while I'm at it!!).

Thanks guys... looking forward to going through these problems and talking to you at the interview!!
