### PR TITLE
Updated rspec dependency version for coding-test-2

### DIFF
--- a/coding-test-2/practice-problems/Gemfile
+++ b/coding-test-2/practice-problems/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'rspec', "~> 2.14.1"
+gem "rspec", "~> 3.2.0"

--- a/coding-test-2/practice-problems/Gemfile.lock
+++ b/coding-test-2/practice-problems/Gemfile.lock
@@ -2,17 +2,22 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rspec (~> 2.14.1)
+  rspec (~> 3.2.0)


### PR DESCRIPTION
When I ran the coding-test-2 tests I received the following error:

```
undefined method `include_chain_clauses_in_custom_matcher_descriptions=' 
for #<RSpec::Expectations::Configuration:0x007fd945923c10> (NoMethodError)
```

It seems this configuration setting is only present in updated versions of rspec. However, the gemfile specified rspec version 2.