### PR TITLE
Fix broken link for Hartl's Rail tutorial

### DIFF
--- a/pre-course/readings.md
+++ b/pre-course/readings.md
@@ -28,5 +28,5 @@ those that have exercises, do them.
 [ruby-in-100-min]: http://tutorials.jumpstartlab.com/projects/ruby_in_100_minutes.html
 [chris-pine]: http://filepi.com/i/kF0llED
 [ruby-primer]: http://rubymonk.com/learning/books/1
-[hartl]: http://ruby.railstutorial.org/ruby-on-rails-tutorial-book
+[hartl]: https://www.railstutorial.org/book
 [shaw-cli]: http://cli.learncodethehardway.org/book/


### PR DESCRIPTION
The link that used to lead to the Rails tutorial book by Hartl, now leads to some unrelated site.  I found the correct link on the same railstutorial.org domain.